### PR TITLE
feat(plan): enhance PLAN.md implementation (issue #15)

### DIFF
--- a/src/plan/cli.ts
+++ b/src/plan/cli.ts
@@ -13,6 +13,7 @@ import { PlanParser } from './parser';
 import { PlanValidator } from './validator';
 import { PlanExecutor } from './executor';
 import type {
+  Plan,
   PlanExecuteOptions,
   PlanValidateOptions,
   ExecutionContext,
@@ -24,7 +25,18 @@ import type {
 // ANSI Color Helpers (avoid ESM chalk issues)
 // ============================================================================
 
-const colors = {
+interface Colors {
+  red: (text: string) => string;
+  green: (text: string) => string;
+  yellow: (text: string) => string;
+  blue: (text: string) => string;
+  magenta: (text: string) => string;
+  cyan: (text: string) => string;
+  gray: (text: string) => string;
+  bold: (text: string) => string;
+}
+
+const colors: Colors = {
   red: (text: string) => `\x1b[31m${text}\x1b[0m`,
   green: (text: string) => `\x1b[32m${text}\x1b[0m`,
   yellow: (text: string) => `\x1b[33m${text}\x1b[0m`,
@@ -374,10 +386,10 @@ Describe the success criteria for this plan.
 // Output Formatting
 // ============================================================================
 
-function printPlanHumanReadable(plan: ReturnType<PlanParser['parse']> extends Promise<infer R> ? (R extends { plan?: infer P } ? P : never) : never): void {
+function printPlanHumanReadable(plan: Plan): void {
   if (!plan) return;
 
-  console.log(colors.blue.bold(`Plan: ${plan.metadata.phase}-${plan.metadata.plan}`));
+  console.log(colors.bold(colors.blue(`Plan: ${plan.metadata.phase}-${plan.metadata.plan}`)));
   console.log(colors.gray(`Type: ${plan.metadata.type} | Wave: ${plan.metadata.wave} | Autonomous: ${plan.metadata.autonomous}`));
   console.log();
 
@@ -412,7 +424,7 @@ function printPlanHumanReadable(plan: ReturnType<PlanParser['parse']> extends Pr
 }
 
 function printValidationResult(validation: ReturnType<PlanValidator['validate']>): void {
-  console.log(colors.blue.bold('Validation Result'));
+  console.log(colors.bold(colors.blue('Validation Result')));
   console.log();
 
   if (validation.valid) {

--- a/src/plan/executor.ts
+++ b/src/plan/executor.ts
@@ -187,7 +187,7 @@ async function executeTask(
         taskId: task.id,
         percent: basePercent + 10,
         message: `[DRY RUN] Completed: ${task.name}`,
-        timestamp: result.endTime,
+        timestamp: result.endTime ?? new Date(),
       });
 
       return result;

--- a/src/plan/index.ts
+++ b/src/plan/index.ts
@@ -34,6 +34,7 @@ export type {
   PlanTask,
   ArtifactDefinition,
   KeyLink,
+  UserSetup,
 
   // Parser types
   ParseResult,
@@ -62,11 +63,18 @@ export type {
   PlanValidateOptions,
 } from './types.js';
 
+// Export JSON Schemas
+export {
+  PLAN_FRONTMATTER_JSON_SCHEMA,
+  PLAN_TASK_JSON_SCHEMA,
+} from './types.js';
+
 // ============================================================================
 // Class Exports
 // ============================================================================
 
 export { PlanParser } from './parser';
+export { resolveContextReferences, clearContextCache } from './parser';
 export { PlanValidator } from './validator';
 export { PlanExecutor } from './executor';
 export { PromptBuilder, planToPrompt, planToPromptSync } from './prompt';

--- a/src/plan/parser.ts
+++ b/src/plan/parser.ts
@@ -250,11 +250,46 @@ function parseYamlLike(
         currentSubSection = 'artifacts';
       } else if (trimmed.startsWith('key_links:')) {
         currentSubSection = 'key_links';
+      } else if (trimmed.startsWith('user_setup:')) {
+        currentSubSection = 'user_setup';
       } else if (indentLevel >= 2 && trimmed.startsWith('- ')) {
         const item = trimmed.substring(2).trim();
 
         if (currentSubSection === 'truths') {
           mustHaves.truths.push(item.replace(/['"]/g, ''));
+        } else if (currentSubSection === 'artifacts' && item.includes(':')) {
+          // Nested artifact property (e.g., "path: src/foo.ts")
+          const colonIdx = item.indexOf(':');
+          const propKey = item.substring(0, colonIdx).trim();
+          const propValue = item.substring(colonIdx + 1).trim().replace(/['"]/g, '');
+          
+          const currentArtifact = mustHaves.artifacts[mustHaves.artifacts.length - 1];
+          if (currentArtifact) {
+            if (propKey === 'path') currentArtifact.path = propValue;
+            else if (propKey === 'provides') currentArtifact.provides = propValue;
+            else if (propKey === 'exports') currentArtifact.exports = propValue.split(',').map(s => s.trim());
+            else if (propKey === 'min_lines') currentArtifact.minLines = parseInt(propValue, 10);
+            else if (propKey === 'contains') currentArtifact.contains = propValue;
+          }
+        } else if (currentSubSection === 'artifacts' && !item.includes(':')) {
+          // New artifact entry
+          mustHaves.artifacts.push({ path: item.replace(/['"]/g, ''), provides: '' });
+        } else if (currentSubSection === 'key_links' && item.includes(':')) {
+          // Nested key_link property
+          const colonIdx = item.indexOf(':');
+          const propKey = item.substring(0, colonIdx).trim();
+          const propValue = item.substring(colonIdx + 1).trim().replace(/['"]/g, '');
+          
+          const currentLink = mustHaves.key_links[mustHaves.key_links.length - 1];
+          if (currentLink) {
+            if (propKey === 'from') currentLink.from = propValue;
+            else if (propKey === 'to') currentLink.to = propValue;
+            else if (propKey === 'via') currentLink.via = propValue;
+            else if (propKey === 'pattern') currentLink.pattern = propValue;
+          }
+        } else if (currentSubSection === 'key_links' && !item.includes(':')) {
+          // New key_link entry
+          mustHaves.key_links.push({ from: '', to: '', via: '' });
         }
       }
     }
@@ -567,6 +602,70 @@ function getLineNumber(content: string, index: number): number {
 }
 
 // ============================================================================
+// @-Reference Resolution
+// ============================================================================
+
+const fileCache = new Map<string, string>();
+
+export interface ResolveContextOptions {
+  projectRoot: string;
+  cache?: boolean;
+}
+
+export async function resolveContextReferences(
+  context: string[],
+  options: ResolveContextOptions
+): Promise<Record<string, string>> {
+  const resolved: Record<string, string> = {};
+  const cache = options.cache !== false;
+
+  for (const ref of context) {
+    const resolvedPath = resolveRefPath(ref, options.projectRoot);
+    
+    if (resolvedPath) {
+      try {
+        let content: string | undefined;
+        
+        if (cache && fileCache.has(resolvedPath)) {
+          content = fileCache.get(resolvedPath);
+        } else {
+          const fs = await import('fs/promises');
+          content = await fs.readFile(resolvedPath, 'utf-8');
+          if (cache) {
+            fileCache.set(resolvedPath, content);
+          }
+        }
+        
+        if (content) {
+          resolved[ref] = content;
+        }
+      } catch {
+        resolved[ref] = `[File not found: ${resolvedPath}]`;
+      }
+    }
+  }
+
+  return resolved;
+}
+
+function resolveRefPath(ref: string, projectRoot: string): string | null {
+  if (ref.startsWith('@.')) {
+    const relativePath = ref.substring(2);
+    return `${projectRoot}/${relativePath}`;
+  } else if (ref.startsWith('@')) {
+    const relativePath = ref.substring(1);
+    return `${projectRoot}/${relativePath}`;
+  } else if (ref.startsWith('/')) {
+    return ref;
+  }
+  return `${projectRoot}/${ref}`;
+}
+
+export function clearContextCache(): void {
+  fileCache.clear();
+}
+
+// ============================================================================
 // Export Parser Class
 // ============================================================================
 
@@ -586,9 +685,19 @@ export class PlanParser {
    * (Node.js environment only)
    */
   async parseFile(filePath: string): Promise<ParseResult> {
-    // Dynamic import to avoid issues in browser environments
     const fs = await import('fs/promises');
     const content = await fs.readFile(filePath, 'utf-8');
     return this.parse(content, filePath);
+  }
+
+  /**
+   * Resolve @-references in context and populate contextResolved
+   */
+  async resolveContext(plan: Plan, projectRoot: string): Promise<Plan> {
+    const resolved = await resolveContextReferences(plan.context, { projectRoot });
+    return {
+      ...plan,
+      contextResolved: resolved,
+    };
   }
 }

--- a/src/plan/types.ts
+++ b/src/plan/types.ts
@@ -10,6 +10,22 @@
 // ============================================================================
 
 /**
+ * User setup requirement for external services
+ */
+export interface UserSetup {
+  service: string;
+  why: string;
+  envVars?: Array<{
+    name: string;
+    source: string;
+  }>;
+  dashboardConfig?: Array<{
+    task: string;
+    location: string;
+  }>;
+}
+
+/**
  * Frontmatter metadata parsed from PLAN.md YAML header
  */
 export interface PlanMetadata {
@@ -21,6 +37,7 @@ export interface PlanMetadata {
   files_modified: string[];
   autonomous: boolean;
   requirements: string[];
+  userSetup?: UserSetup[];
 }
 
 /**
@@ -38,7 +55,9 @@ export interface PlanMustHaves {
 export interface ArtifactDefinition {
   path: string;
   provides: string;
-  exports: string[];
+  exports?: string[];
+  minLines?: number;
+  contains?: string;
 }
 
 /**
@@ -48,6 +67,7 @@ export interface KeyLink {
   from: string;
   to: string;
   via: string;
+  pattern?: string;
 }
 
 /**
@@ -64,6 +84,8 @@ export interface Plan {
   executionContext?: string;
   /** Context file references */
   context: string[];
+  /** Resolved context content (for @-references) */
+  contextResolved?: Record<string, string>;
   /** Parsed tasks */
   tasks: PlanTask[];
   /** Verification checklist */
@@ -403,3 +425,152 @@ export interface PlanValidateOptions {
   /** Strict mode (warnings as errors) */
   strict?: boolean;
 }
+
+// ============================================================================
+// JSON Schema Types
+// ============================================================================
+
+/**
+ * JSON Schema for PLAN.md frontmatter validation
+ */
+export const PLAN_FRONTMATTER_JSON_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  required: ['phase', 'plan', 'type'],
+  properties: {
+    phase: {
+      type: 'string',
+      pattern: '^[0-9]{2}-[a-z]+$',
+      description: 'Phase identifier (e.g., 01-foundation)',
+    },
+    plan: {
+      type: 'string',
+      pattern: '^[0-9]{2}$',
+      description: 'Plan number within phase (01, 02, etc.)',
+    },
+    type: {
+      type: 'string',
+      enum: ['execute', 'research', 'design', 'tdd'],
+      description: 'Plan execution type',
+    },
+    wave: {
+      type: 'number',
+      minimum: 1,
+      description: 'Execution wave (1, 2, 3...)',
+    },
+    depends_on: {
+      type: 'array',
+      items: {
+        type: 'string',
+        pattern: '^[0-9]{2}-[0-9]{2}$',
+      },
+      description: 'Plan IDs this depends on',
+    },
+    files_modified: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Files this plan will modify',
+    },
+    autonomous: {
+      type: 'boolean',
+      description: 'false if contains checkpoints',
+    },
+    requirements: {
+      type: 'array',
+      items: {
+        type: 'string',
+        pattern: '^REQ-[0-9]+$',
+      },
+      description: 'Requirement IDs from ROADMAP',
+    },
+    user_setup: {
+      type: 'array',
+      items: {
+        type: 'object',
+        required: ['service', 'why'],
+        properties: {
+          service: { type: 'string' },
+          why: { type: 'string' },
+          env_vars: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                source: { type: 'string' },
+              },
+            },
+          },
+          dashboard_config: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                task: { type: 'string' },
+                location: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    },
+    must_haves: {
+      type: 'object',
+      properties: {
+        truths: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+        artifacts: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['path', 'provides'],
+            properties: {
+              path: { type: 'string' },
+              provides: { type: 'string' },
+              exports: { type: 'array', items: { type: 'string' } },
+              min_lines: { type: 'number' },
+              contains: { type: 'string' },
+            },
+          },
+        },
+        key_links: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['from', 'to', 'via'],
+            properties: {
+              from: { type: 'string' },
+              to: { type: 'string' },
+              via: { type: 'string' },
+              pattern: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+  },
+} as const;
+
+/**
+ * JSON Schema for task validation
+ */
+export const PLAN_TASK_JSON_SCHEMA = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  type: 'object',
+  required: ['name', 'action'],
+  properties: {
+    type: {
+      type: 'string',
+      enum: ['auto', 'manual', 'decision', 'checkpoint:human-verify', 'checkpoint:decision', 'checkpoint:human-action'],
+    },
+    tdd: { type: 'boolean' },
+    name: { type: 'string', minLength: 1 },
+    files: { type: 'array', items: { type: 'string' } },
+    action: { type: 'string', minLength: 1 },
+    verify: { type: 'string' },
+    done: { type: 'string' },
+    behavior: { type: 'array', items: { type: 'string' } },
+  },
+} as const;


### PR DESCRIPTION
## Summary
- Implemented JSON Schema for frontmatter validation (PLAN_FRONTMATTER_JSON_SCHEMA, PLAN_TASK_JSON_SCHEMA)
- Enhanced must_haves parsing for nested artifacts (path, provides, exports, min_lines, contains) and key_links (from, to, via, pattern)
- Added UserSetup interface for external service requirements
- Added @-reference resolution system with file caching
- Added resolveContext method to PlanParser for loading context files
- Fixed type issues in executor.ts and cli.ts

## Changes
- `src/plan/types.ts`: Added UserSetup, JSON schemas, updated interfaces
- `src/plan/parser.ts`: Enhanced YAML parsing, added resolveContextReferences
- `src/plan/cli.ts`: Fixed type issues
- `src/plan/executor.ts`: Fixed timestamp error
- `src/plan/index.ts`: Added exports for new functionality

Closes #15